### PR TITLE
QTIK-738: NO_ALGOMAN_CONNECTION 

### DIFF
--- a/docs/mktdata.md
+++ b/docs/mktdata.md
@@ -734,6 +734,8 @@ para o QuitReason são:
 
 -   NO_OMS_CONNECTION: sem conexão com o OMS
 
+-   NO_ALGOMAN_CONNECTION: sem conexão com o Algoman
+
 ### Callback default, book, trade e candles
 
 O controle do volume de notificações recebidas é feito em parte pelo


### PR DESCRIPTION
@ucaiado 

NO_ALGOMAN_CONNECTION foi adicionado aos enumerados de reason-quit.

Como pedido no ticket [QTIK-738](https://onesoft.atlassian.net/browse/QTIK-738).
